### PR TITLE
Fix scene loading workflow

### DIFF
--- a/VCGameFramework/Assets/GameScripts/LaunchScript/LaunchScript.cs
+++ b/VCGameFramework/Assets/GameScripts/LaunchScript/LaunchScript.cs
@@ -3,6 +3,7 @@ using MessagePipe;
 using UnityEngine;
 using VContainer;
 using VContainer.Unity;
+using Cysharp.Threading.Tasks;
 
 public class LaunchScript : IStartable
 {
@@ -28,13 +29,14 @@ public class LaunchScript : IStartable
     {
         if (eventId == 1002)
         {
-            SwitchScene();
+            SwitchScene().Forget();
         }
     }
 
-    private void SwitchScene()
+    private async UniTaskVoid SwitchScene()
     {
         Debug.Log("LaunchAnimEnd -> SwitchScene");
-        sceneManager.LoadSceneAsync("HotUpdate").Forget();
+        await sceneManager.LoadSceneAsync("HotUpdate");
+        await sceneManager.ActivateLoadedScene();
     }
 }

--- a/VCGameFramework/Assets/GameScripts/Modules/Scene/SceneLoadModule/Runtime/CustomSceneManager.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Scene/SceneLoadModule/Runtime/CustomSceneManager.cs
@@ -23,22 +23,25 @@ namespace GameScripts.Modules.Scene.Runtime
         /// </summary>
         /// <param name="sceneName">场景名称</param>
         /// <param name="onComplete">完成后回调</param>
-        public async UniTaskVoid LoadSceneAsync(string sceneName, Action onComplete = null)
+        public async UniTask LoadSceneAsync(string sceneName, Action onComplete = null)
         {
             Debug.Log($"开始加载场景: {sceneName}");
 
             preloadSceneName = sceneName;
 
             preloadOperation = SceneManager.LoadSceneAsync(sceneName);
-            preloadOperation.allowSceneActivation = true;
+            // 先加载但不激活，由外部在合适时机调用 ActivateLoadedScene
+            preloadOperation.allowSceneActivation = false;
 
-            while (!preloadOperation.isDone)
+            // allowSceneActivation 为 false 时，isDone 始终为 false
+            // 因此只需等待到进度达到 0.9（加载完成但未激活）即可
+            while (preloadOperation.progress < 0.9f)
             {
                 Debug.Log($"加载进度: {preloadOperation.progress * 100f:0.0}%");
                 await UniTask.Yield(); // 每帧等待
             }
 
-            Debug.Log("场景加载完成");
+            Debug.Log("场景加载完成，等待激活");
 
             onComplete?.Invoke();
         }


### PR DESCRIPTION
## Summary
- update `CustomSceneManager.LoadSceneAsync` to wait until progress reaches 0.9 and return `UniTask`
- switch scenes asynchronously in `LaunchScript`

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_68776af27a7c832785201b29ed42edf5