### PR TITLE
Add async module initialization system

### DIFF
--- a/VCGameFramework/Assets/GameScripts/Core/IAsyncModule.cs
+++ b/VCGameFramework/Assets/GameScripts/Core/IAsyncModule.cs
@@ -1,0 +1,10 @@
+using Cysharp.Threading.Tasks;
+using VContainer;
+
+namespace Game.Core
+{
+    public interface IAsyncModule : IModule
+    {
+        UniTask InitializeAsync(IObjectResolver resolver);
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Core/ModuleInitializer.cs
+++ b/VCGameFramework/Assets/GameScripts/Core/ModuleInitializer.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using VContainer;
+using VContainer.Unity;
+
+namespace Game.Core
+{
+    public class ModuleInitializer : IStartable
+    {
+        readonly IReadOnlyList<IAsyncModule> modules;
+        readonly IObjectResolver resolver;
+
+        public ModuleInitializer(IReadOnlyList<IAsyncModule> modules, IObjectResolver resolver)
+        {
+            this.modules = modules;
+            this.resolver = resolver;
+        }
+
+        public void Start()
+        {
+            Initialize().Forget();
+        }
+
+        private async UniTaskVoid Initialize()
+        {
+            foreach (var module in modules)
+            {
+                await module.InitializeAsync(resolver);
+            }
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Core/ModuleLoader.cs
+++ b/VCGameFramework/Assets/GameScripts/Core/ModuleLoader.cs
@@ -2,17 +2,29 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using VContainer;
+using VContainer.Unity;
 
 namespace Game.Core
 {
     public static class ModuleLoader
     {
+        static readonly List<IAsyncModule> asyncModules = new();
+
         public static void RegisterAllModules(IContainerBuilder builder)
         {
+            asyncModules.Clear();
             var modules = DiscoverModules();
             foreach (var module in modules)
             {
                 module.Configure(builder);
+                if (module is IAsyncModule asyncModule)
+                    asyncModules.Add(asyncModule);
+            }
+
+            if (asyncModules.Count > 0)
+            {
+                builder.RegisterInstance<IReadOnlyList<IAsyncModule>>(asyncModules);
+                builder.RegisterEntryPoint<ModuleInitializer>(Lifetime.Singleton);
             }
         }
 

--- a/VCGameFramework/Assets/GameScripts/Modules/Resource/Application/ResourceModule.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Resource/Application/ResourceModule.cs
@@ -2,10 +2,11 @@ using Game.Core;
 using Game.Modules.Resource.Infrastructure;
 using Game.Modules.Resource.Domain;
 using VContainer;
+using Cysharp.Threading.Tasks;
 
 namespace Game.Modules.Resource.Application
 {
-    public class ResourceModule : IModuleWithOrder
+    public class ResourceModule : IModuleWithOrder, IAsyncModule
     {
         //[SerializeField] private ScriptableResourceConfig resourceConfig;
         public int Order => -99;
@@ -14,6 +15,11 @@ namespace Game.Modules.Resource.Application
             //builder.RegisterInstance(resourceConfig.ToConfig());
             builder.Register<IResourceService, YooAssetResourceProvider>(Lifetime.Singleton);
             builder.Register<ResourceService>(Lifetime.Singleton);
+        }
+
+        public async UniTask InitializeAsync(IObjectResolver resolver)
+        {
+            await resolver.Resolve<ResourceService>().InitializeAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `IAsyncModule` interface for modules needing asynchronous setup
- implement `ModuleInitializer` entry point to run async initialization
- extend `ModuleLoader` to register async modules and entry point
- enable resource module to perform initialization asynchronously

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778a7ca270832786a5474c8452422a