### PR TITLE
Add basic DI modules and UI scopes

### DIFF
--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Application/ProjectModule.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Application/ProjectModule.cs
@@ -1,0 +1,21 @@
+using Game.Core;
+using Game.Modules.Global.Domain;
+using Game.Modules.Global.Infrastructure;
+using VContainer;
+
+namespace Game.Modules.Global.Application
+{
+    public class ProjectModule : IModuleWithOrder
+    {
+        public int Order => -1000;
+
+        public void Configure(IContainerBuilder builder)
+        {
+            builder.Register<INetworkService, NetworkService>(Lifetime.Singleton);
+            builder.Register<IAccountService, AccountService>(Lifetime.Singleton);
+            builder.Register<IMasterDataService, MasterDataService>(Lifetime.Singleton);
+            builder.Register<IInventoryService, InventoryService>(Lifetime.Singleton);
+            builder.Register<IGlobalEventBus, GlobalEventBus>(Lifetime.Singleton);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IAccountService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IAccountService.cs
@@ -1,0 +1,10 @@
+namespace Game.Modules.Global.Domain
+{
+    using Cysharp.Threading.Tasks;
+
+    public interface IAccountService
+    {
+        UniTask LoginAsync(string username, string password);
+        void Logout();
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IGlobalEventBus.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IGlobalEventBus.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Game.Modules.Global.Domain
+{
+    public interface IGlobalEventBus
+    {
+        void Publish<T>(T message);
+        void Subscribe<T>(Action<T> handler);
+        void Unsubscribe<T>(Action<T> handler);
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IInventoryService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IInventoryService.cs
@@ -1,0 +1,12 @@
+namespace Game.Modules.Global.Domain
+{
+    using Cysharp.Threading.Tasks;
+    using System.Collections.Generic;
+
+    public interface IInventoryService
+    {
+        UniTask InitializeAsync();
+        IReadOnlyList<string> Items { get; }
+        void AddItem(string item);
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IMasterDataService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/IMasterDataService.cs
@@ -1,0 +1,9 @@
+namespace Game.Modules.Global.Domain
+{
+    using Cysharp.Threading.Tasks;
+
+    public interface IMasterDataService
+    {
+        UniTask LoadAsync();
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/INetworkService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Domain/INetworkService.cs
@@ -1,0 +1,10 @@
+namespace Game.Modules.Global.Domain
+{
+    using Cysharp.Threading.Tasks;
+
+    public interface INetworkService
+    {
+        UniTask ConnectAsync();
+        UniTask SendAsync(string message);
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/AccountService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/AccountService.cs
@@ -1,0 +1,27 @@
+using Cysharp.Threading.Tasks;
+using Game.Modules.Global.Domain;
+using UnityEngine;
+
+namespace Game.Modules.Global.Infrastructure
+{
+    public class AccountService : IAccountService
+    {
+        private readonly INetworkService _network;
+
+        public AccountService(INetworkService network)
+        {
+            _network = network;
+        }
+
+        public async UniTask LoginAsync(string username, string password)
+        {
+            await _network.ConnectAsync();
+            Debug.Log($"[Account] Login as {username}");
+        }
+
+        public void Logout()
+        {
+            Debug.Log("[Account] Logout");
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/GlobalEventBus.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/GlobalEventBus.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using Game.Modules.Global.Domain;
+
+namespace Game.Modules.Global.Infrastructure
+{
+    public class GlobalEventBus : IGlobalEventBus
+    {
+        private readonly Dictionary<Type, Delegate> _listeners = new();
+
+        public void Publish<T>(T message)
+        {
+            if (_listeners.TryGetValue(typeof(T), out var d))
+            {
+                var callback = d as Action<T>;
+                callback?.Invoke(message);
+            }
+        }
+
+        public void Subscribe<T>(Action<T> handler)
+        {
+            if (_listeners.TryGetValue(typeof(T), out var d))
+            {
+                _listeners[typeof(T)] = Delegate.Combine(d, handler);
+            }
+            else
+            {
+                _listeners[typeof(T)] = handler;
+            }
+        }
+
+        public void Unsubscribe<T>(Action<T> handler)
+        {
+            if (_listeners.TryGetValue(typeof(T), out var d))
+            {
+                var current = Delegate.Remove(d, handler);
+                if (current == null)
+                    _listeners.Remove(typeof(T));
+                else
+                    _listeners[typeof(T)] = current;
+            }
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/InventoryService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/InventoryService.cs
@@ -1,0 +1,16 @@
+using Cysharp.Threading.Tasks;
+using Game.Modules.Global.Domain;
+using System.Collections.Generic;
+
+namespace Game.Modules.Global.Infrastructure
+{
+    public class InventoryService : IInventoryService
+    {
+        private readonly List<string> _items = new();
+        public IReadOnlyList<string> Items => _items;
+
+        public UniTask InitializeAsync() => UniTask.CompletedTask;
+
+        public void AddItem(string item) => _items.Add(item);
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/MasterDataService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/MasterDataService.cs
@@ -1,0 +1,13 @@
+using Cysharp.Threading.Tasks;
+using Game.Modules.Global.Domain;
+
+namespace Game.Modules.Global.Infrastructure
+{
+    public class MasterDataService : IMasterDataService
+    {
+        public async UniTask LoadAsync()
+        {
+            await UniTask.Delay(100);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/NetworkService.cs
+++ b/VCGameFramework/Assets/GameScripts/Modules/Global/Infrastructure/NetworkService.cs
@@ -1,0 +1,21 @@
+using Cysharp.Threading.Tasks;
+using Game.Modules.Global.Domain;
+using UnityEngine;
+
+namespace Game.Modules.Global.Infrastructure
+{
+    public class NetworkService : INetworkService
+    {
+        public async UniTask ConnectAsync()
+        {
+            Debug.Log("[Network] Connect");
+            await UniTask.Delay(500);
+        }
+
+        public async UniTask SendAsync(string message)
+        {
+            Debug.Log("[Network] Send: " + message);
+            await UniTask.Delay(10);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/DungeonLifetimeScope.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/DungeonLifetimeScope.cs
@@ -1,0 +1,14 @@
+using VContainer;
+using VContainer.Unity;
+
+namespace Game.Scenes.Dungeon
+{
+    public class DungeonLifetimeScope : LifetimeScope
+    {
+        protected override void Configure(IContainerBuilder builder)
+        {
+            builder.RegisterEntryPoint<DungeonProgressManager>(Lifetime.Scoped);
+            builder.RegisterEntryPoint<MonsterSpawnController>(Lifetime.Scoped);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/DungeonProgressManager.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/DungeonProgressManager.cs
@@ -1,0 +1,9 @@
+using VContainer.Unity;
+
+namespace Game.Scenes.Dungeon
+{
+    public class DungeonProgressManager : IStartable
+    {
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/MonsterSpawnController.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/Dungeon/MonsterSpawnController.cs
@@ -1,0 +1,9 @@
+using VContainer.Unity;
+
+namespace Game.Scenes.Dungeon
+{
+    public class MonsterSpawnController : IStartable
+    {
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/MainCity/AuctionHouseController.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/MainCity/AuctionHouseController.cs
@@ -1,0 +1,9 @@
+using VContainer.Unity;
+
+namespace Game.Scenes.MainCity
+{
+    public class AuctionHouseController : IStartable
+    {
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/MainCity/ChatManager.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/MainCity/ChatManager.cs
@@ -1,0 +1,9 @@
+using VContainer.Unity;
+
+namespace Game.Scenes.MainCity
+{
+    public class ChatManager : IStartable
+    {
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/Scenes/MainCity/MainCityLifetimeScope.cs
+++ b/VCGameFramework/Assets/GameScripts/Scenes/MainCity/MainCityLifetimeScope.cs
@@ -1,0 +1,14 @@
+using VContainer;
+using VContainer.Unity;
+
+namespace Game.Scenes.MainCity
+{
+    public class MainCityLifetimeScope : LifetimeScope
+    {
+        protected override void Configure(IContainerBuilder builder)
+        {
+            builder.RegisterEntryPoint<ChatManager>(Lifetime.Scoped);
+            builder.RegisterEntryPoint<AuctionHouseController>(Lifetime.Scoped);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryPresenter.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryPresenter.cs
@@ -1,0 +1,27 @@
+using Game.Modules.Global.Domain;
+using System;
+using VContainer.Unity;
+
+namespace Game.UI.Inventory
+{
+    public class InventoryPresenter : IStartable, IDisposable
+    {
+        private readonly IInventoryService _service;
+        private readonly InventoryView _view;
+
+        public InventoryPresenter(IInventoryService service, InventoryView view)
+        {
+            _service = service;
+            _view = view;
+        }
+
+        public void Start()
+        {
+            UnityEngine.Debug.Log($"Inventory items: {_service.Items.Count}");
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryView.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryView.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace Game.UI.Inventory
+{
+    public class InventoryView : MonoBehaviour
+    {
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryWindowLifetimeScope.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Inventory/InventoryWindowLifetimeScope.cs
@@ -1,0 +1,14 @@
+using VContainer;
+using VContainer.Unity;
+
+namespace Game.UI.Inventory
+{
+    public class InventoryWindowLifetimeScope : LifetimeScope
+    {
+        protected override void Configure(IContainerBuilder builder)
+        {
+            builder.RegisterComponentInHierarchy<InventoryView>();
+            builder.RegisterEntryPoint<InventoryPresenter>(Lifetime.Scoped);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/HUDPresenter.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/HUDPresenter.cs
@@ -1,0 +1,11 @@
+using VContainer.Unity;
+
+namespace Game.UI.Main
+{
+    public class HUDPresenter : IStartable
+    {
+        private readonly HUDView _view;
+        public HUDPresenter(HUDView view) => _view = view;
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/HUDView.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/HUDView.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace Game.UI.Main
+{
+    public class HUDView : MonoBehaviour
+    {
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/MainUILifetimeScope.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/MainUILifetimeScope.cs
@@ -1,0 +1,19 @@
+using VContainer;
+using VContainer.Unity;
+
+namespace Game.UI.Main
+{
+    public class MainUILifetimeScope : LifetimeScope
+    {
+        protected override void Configure(IContainerBuilder builder)
+        {
+            builder.RegisterComponentInHierarchy<HUDView>();
+            builder.RegisterComponentInHierarchy<MinimapView>();
+            builder.RegisterComponentInHierarchy<QuestTrackerView>();
+
+            builder.RegisterEntryPoint<HUDPresenter>(Lifetime.Scoped);
+            builder.RegisterEntryPoint<MinimapPresenter>(Lifetime.Scoped);
+            builder.RegisterEntryPoint<QuestTrackerPresenter>(Lifetime.Scoped);
+        }
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/MinimapPresenter.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/MinimapPresenter.cs
@@ -1,0 +1,11 @@
+using VContainer.Unity;
+
+namespace Game.UI.Main
+{
+    public class MinimapPresenter : IStartable
+    {
+        private readonly MinimapView _view;
+        public MinimapPresenter(MinimapView view) => _view = view;
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/MinimapView.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/MinimapView.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace Game.UI.Main
+{
+    public class MinimapView : MonoBehaviour
+    {
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/QuestTrackerPresenter.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/QuestTrackerPresenter.cs
@@ -1,0 +1,11 @@
+using VContainer.Unity;
+
+namespace Game.UI.Main
+{
+    public class QuestTrackerPresenter : IStartable
+    {
+        private readonly QuestTrackerView _view;
+        public QuestTrackerPresenter(QuestTrackerView view) => _view = view;
+        public void Start() {}
+    }
+}

--- a/VCGameFramework/Assets/GameScripts/UI/Main/QuestTrackerView.cs
+++ b/VCGameFramework/Assets/GameScripts/UI/Main/QuestTrackerView.cs
@@ -1,0 +1,8 @@
+using UnityEngine;
+
+namespace Game.UI.Main
+{
+    public class QuestTrackerView : MonoBehaviour
+    {
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ProjectModule` to register core services like network, account, inventory and global event bus
- add simple services and interfaces for global systems
- provide demo scene lifetime scopes and UI lifetime scopes using VContainer
- include inventory window and main UI presenters for dynamic scopes

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68779823039c8327bf2eb7259b95d534