### PR TITLE
fix: 清理临时音效时使用实时等待

### DIFF
--- a/VCGameFramework/Assets/Game/HotFix/Infrastructure/Managers/AudioManager.cs
+++ b/VCGameFramework/Assets/Game/HotFix/Infrastructure/Managers/AudioManager.cs
@@ -623,7 +623,8 @@ namespace Game.Infrastructure.Managers
         /// </summary>
         private IEnumerator CleanupTempSFX(AudioSource source, GameObject tempObject, float delay)
         {
-            yield return new WaitForSeconds(delay + 0.1f); // 多等待0.1秒确保播放完成
+            // 使用实时等待避免在游戏暂停或时间缩放改变时遗留临时对象
+            yield return new WaitForSecondsRealtime(delay + 0.1f); // 多等待0.1秒确保播放完成
             
             if (source != null)
             {


### PR DESCRIPTION
## Summary
- 避免时间缩放影响临时音效清理，改用 `WaitForSecondsRealtime`

## Testing
- `unity -batchmode -projectPath VCGameFramework -runTests -testPlatform EditMode -logFile Logs/tests-edit.log -testResults Logs/editmode-results.xml -quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd25baf4a08327afac95376b1a36d1