### PR TITLE
feat: 添加资源注册表 TTL 清理功能

### DIFF
--- a/VCGameFramework/Assets/Game/HotFix/AssetSystem/Core/AssetRegistry.cs
+++ b/VCGameFramework/Assets/Game/HotFix/AssetSystem/Core/AssetRegistry.cs
@@ -12,12 +12,14 @@ namespace Game.HotFix.AssetSystem.Core
     /// IAssetRegistry 默认实现（Singleton）：
     /// - 使用 address -> Entry 的字典管理 YooAsset 句柄与 RefCount。
     /// - Pin/Lease 统一走 Entry，Lease.Dispose/Pin 归还会减少 RefCount 并在为 0 时释放句柄。
-    /// - 预留 TTL/统计/调试 UI 钩子（此版本不实现，留给项目侧按需扩展）。
+    /// - 内置 TTL 淘汰：未被访问且引用计数为 0 的条目在清理时会释放。
+    /// - 预留统计/调试 UI 钩子（此版本不实现，留给项目侧按需扩展）。
     /// </summary>
     public sealed class AssetRegistry : IAssetRegistry, IDisposable
     {
         private readonly Dictionary<string, Entry> _entries = new();
         private readonly object _gate = new();
+        private readonly TimeSpan _timeToLive = TimeSpan.FromMinutes(10);
         private bool _disposed;
 
         private sealed class Entry
@@ -52,11 +54,40 @@ namespace Game.HotFix.AssetSystem.Core
             handle.Release();
         }
 
-        public UniTask CleanupAsync(CancellationToken ct = default)
+        public async UniTask CleanupAsync(CancellationToken ct = default)
         {
-            // 预留：可在此加入 TTL 淘汰、TopN 统计、调用 YooAssets.UnloadUnusedAssetsAsync 等
-            // 为减少入侵度，此处先空实现，交由上层在合适时机调用 YooAssets.UnloadUnusedAssetsAsync。
-            return UniTask.CompletedTask;
+            ThrowIfDisposed();
+            List<string> toRemove = null;
+            lock (_gate)
+            {
+                var now = DateTime.UtcNow;
+                foreach (var kv in _entries)
+                {
+                    var entry = kv.Value;
+                    if (entry.RefCount <= 0 && now - entry.LastAccess > _timeToLive)
+                    {
+                        (toRemove ??= new()).Add(kv.Key);
+                    }
+                }
+
+                if (toRemove != null)
+                {
+                    foreach (var key in toRemove)
+                    {
+                        if (_entries.TryGetValue(key, out var entry))
+                        {
+                            entry.Handle?.Release();
+                            _entries.Remove(key);
+                        }
+                    }
+                }
+            }
+
+            // 同步 YooAsset 包缓存，释放未使用资源
+            var package = YooAssets.GetPackage("DefaultPackage");
+            var operation = package.UnloadUnusedAssetsAsync();
+            operation.WaitForAsyncComplete(); // 支持同步操作
+            await operation.ToUniTask(cancellationToken: ct);
         }
 
         private async UniTask<Entry> GetOrLoadEntryAsync<T>(string address, CancellationToken ct) where T : UnityEngine.Object

--- a/VCGameFramework/Assets/Game/HotFix/AssetSystem/README.md
+++ b/VCGameFramework/Assets/Game/HotFix/AssetSystem/README.md
@@ -4,10 +4,11 @@ Game.HotFix.AssetSystem（YooAsset句柄+VContainer生命周期）
 - Registry（Singleton）：集中管理 address -> YooAsset 句柄与 RefCount；屏蔽业务对 YooAsset 的直接依赖。
 - Scope（Scoped/按需创建）：绑定业务生命周期（UI/系统/流程）；Pin 资源随 Scope.Dispose 统一释放。
 - API：IAssetRegistry.PinAsync/LeaseAsync/PreloadAsync，IAssetScope 同名转调。
+- Cleanup：Registry.CleanupAsync 支持 TTL 淘汰无引用资源。
 - 迁移策略：删除旧 Resource 系统代码后，业务通过 Scope/Registry 获取资源；UI 通过 ScopedUIResourceLoader 适配，无需改动 UISystem。
 
 未实现（留空扩展）
-- TTL 淘汰与 TopN 统计
+- TopN 统计
 - 调试覆盖层 UI 与指标
 - Address 映射与标签筛选
 - 场景句柄的高级策略


### PR DESCRIPTION
## Summary
- 引入内置 TTL 策略，在清理时自动释放长时间未使用的资源
- 更新 CleanupAsync，使用包级 `UnloadUnusedAssetsAsync` 以正确释放 YooAsset 缓存
- 更新资产系统说明文档，移除已实现的 TTL TODO

## Testing
- `Unity -batchmode -projectPath "$(pwd)/VCGameFramework" -runTests -testPlatform EditMode -logFile Logs/tests-edit.log -testResults Logs/editmode-results.xml -quit` *(command not found: Unity)*

------
https://chatgpt.com/codex/tasks/task_e_68bd27147f208327bdbdb2da31cb17f3